### PR TITLE
add facility header

### DIFF
--- a/cmd/aws-s3-proxy/pkg/serve.go
+++ b/cmd/aws-s3-proxy/pkg/serve.go
@@ -80,6 +80,9 @@ func init() {
 	serveCmd.Flags().String("cors-allow-origin", "", "CORS: a URI that may access the resource")
 	viperBindFlag("corsalloworigin", serveCmd.Flags().Lookup("cors-allow-origin"))
 
+	serveCmd.Flags().String("facility", "", "Location where the service is running")
+	viperBindFlag("facility", serveCmd.Flags().Lookup("facility"))
+
 	serveCmd.Flags().String("healthcheck-path", "", "path for healthcheck")
 	viperBindFlag("healthcheckpath", serveCmd.Flags().Lookup("healthcheck-path"))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type config struct { // nolint
 	DisableCompression bool               // DISABLE_COMPRESSION
 	DisableUpstreamSSL bool               // Disables SSL in the aws-sdk
 	EnableUpload       bool               // Toggles upload
+	Facility           string             // Location the service is running in
 	GuessBucketTimeout time.Duration      // Used by region helper
 	HealthCheckPath    string             // HEALTHCHECK_PATH
 	HTTPCacheControl   string             // HTTP_CACHE_CONTROL (max-age=86400, no-cache ...)

--- a/internal/http/handler-wrapper.go
+++ b/internal/http/handler-wrapper.go
@@ -54,6 +54,11 @@ func WrapHandler(handler func(w http.ResponseWriter, r *http.Request)) http.Hand
 			addr = ip
 		}
 
+		// Facility Header if set
+		if len(c.Facility) > 0 {
+			w.Header().Add("Facility", c.Facility)
+		}
+
 		// Content-Encoding
 		ioWriter := w.(io.Writer)
 		if encodings, found := header(r, "Accept-Encoding"); found && c.ContentEncoding {


### PR DESCRIPTION
* Adds facility header for ease of use / debugging in prod.

Tested locally 
```bash
$ curl localhost:21080/_healthcheck -v    
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 21080 (#0)
> GET /_healthcheck HTTP/1.1
> Host: localhost:21080
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Length: 3
< Content-Type: binary/octet-stream
< Etag: "eff5bc1ef8ec9d03e640fc4370f5eacd"
< Last-Modified: Tue, 25 May 2021 17:29:27 GMT
< Date: Mon, 28 Jun 2021 16:18:19 GMT
<
ok
* Connection #0 to host localhost left intact
* Closing connection 0
$ curl localhost:21080/_healthcheck -v      
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 21080 (#0)
> GET /_healthcheck HTTP/1.1
> Host: localhost:21080
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Length: 3
< Content-Type: binary/octet-stream
< Etag: "eff5bc1ef8ec9d03e640fc4370f5eacd"
< Facility: local
< Last-Modified: Tue, 25 May 2021 17:29:27 GMT
< Date: Mon, 28 Jun 2021 16:18:28 GMT
<
ok
* Connection #0 to host localhost left intact
* Closing connection 0
```